### PR TITLE
Use /usr/local64 for all pot configuration

### DIFF
--- a/files/extra-files/etc/rc.d/dsbd_lab
+++ b/files/extra-files/etc/rc.d/dsbd_lab
@@ -29,20 +29,14 @@ configure_pot() {
     fi
     cd "$HOME/pot"
 
-    mkdir -p /usr/local/etc/pot  # Assuming configuration files still go to /usr/local/etc/pot
+    # Copying to /usr/local64 for the hybrid ABI port
+    for dir in bin etc share; do
+        cp -fR ./$dir /usr/local64/
+    done
+
     echo "# pot configuration file
 POT_CACHE=/opt/pot/cache
-POT_EXTIF=vtnet0" > /usr/local/etc/pot/pot.conf
-
-    # Correctly copying to /usr/local64 for CheriBSD
-    for dir in bin etc share; do
-        # Adjusting the script to check if we're copying 'etc' to maintain the structure
-        if [ "$dir" = "etc" ]; then
-            cp -fR ./$dir/pot /usr/local/etc/
-        else
-            cp -fR ./$dir /usr/local64/
-        fi
-    done
+POT_EXTIF=vtnet0" > /usr/local64/etc/pot/pot.conf
 }
 
 install_act() {


### PR DESCRIPTION
This function presently echoes configuration to `/usr/local/etc/pot/pot.conf` that isn't read or expected by `/usr/local64/bin/pot`. A simple fix is to avoid `/usr/local` and revert to `/usr/local64`.

It's currently broken.

Both the ported version of Pot and our fork assume that the target is the hybrid ABI, using `/usr/local64`. To maintain convention, `/usr/local` ought to be reserved for capability-aware ports only.