### PR TITLE
Add patches to complete the start-up script

### DIFF
--- a/files/extra-files/etc/rc.d/dsbd_lab
+++ b/files/extra-files/etc/rc.d/dsbd_lab
@@ -36,10 +36,12 @@ configure_pot() {
         cp -fR ./$dir /usr/local64/
     done
 
-    # Enable the virtual NIC
+    # Enable the virtual NIC, basic logging, and VNET isolation
     echo "# pot configuration file
 POT_CACHE=/opt/pot/cache
-POT_EXTIF=vtnet0" > /usr/local64/etc/pot/pot.conf
+POT_EXTIF=vtnet0
+POT_ISOLATE_VNET_POTS=true
+POT_LOG_FACILITY=local2" > /usr/local64/etc/pot/pot.conf
 
     /usr/local64/bin/pot init
 


### PR DESCRIPTION
This PR depends on [#5](https://github.com/digicatapult/act-pot-cheribsd/pull/5) for [act-pot-cheribsd](https://github.com/digicatapult/act-pot-cheribsd/), to remove any duplication around the creation of base pots.