### PR TITLE
Fixing SMB location and ro/rw

### DIFF
--- a/files/extra-files/etc/rc.d/dsbd_lab
+++ b/files/extra-files/etc/rc.d/dsbd_lab
@@ -10,8 +10,7 @@ name="dsbd_lab"
 rcvar="dsbd_lab_enable"
 start_cmd="dsbd_lab_start"
 
-mount_point="/mnt/qemu_smb"
-smb_share="//10.0.2.4/qemu"
+mount_point="/mnt"
 
 enable_runners() {
     # Enable the packages' rc.d scripts
@@ -66,16 +65,6 @@ setup_zfs() {
     zfs list | grep -q "/opt/pot/jails" || zfs create -o mountpoint=/opt/pot/jails -o overlay=on -o compression=on jailroot/jails
     zfs mount -a
     zpool upgrade zroot
-}
-
-check_and_mount_smb() {
-    if ! mount | grep -q "on ${mount_point} "; then
-        mkdir -p ${mount_point}
-        mount_smbfs -o ro -I 10.0.2.4 -N ${smb_share} ${mount_point} || {
-            echo "[error] Failed to mount ${smb_share} on ${mount_point}"
-            return 1
-        }
-    fi
 }
 
 set_env_vars() {
@@ -159,7 +148,6 @@ UsePAM no"
 }
 
 dsbd_lab_start() {
-    check_and_mount_smb
     set_env_vars
 
     setup_zfs

--- a/files/qemu-morello.service
+++ b/files/qemu-morello.service
@@ -16,7 +16,7 @@ ExecStart=/output/sdk/bin/qemu-system-morello \
     -drive if=none,file=/output/jailroot-disk.zfs.qcow2,id=drv1,format=qcow2 \
     -device virtio-blk-pci,drive=drv1 \
     -device virtio-net-pci,netdev=net0 \
-    -netdev 'user,id=net0,hostfwd=tcp::10005-:22,smb=/etc/qemu-morello/smbshare<<<smbshare@ro'
+    -netdev 'user,id=net0,hostfwd=tcp::10005-:22,smb=/etc/qemu-morello/smbshare<<<smbshare@rw'
 ExecStop=/bin/kill $MAINPID
 Restart=on-failure
 StandardOutput=append:/var/log/qemu-morello.log


### PR DESCRIPTION
This PR fixes a bug whereby CheriBSD was automounting the smb share prior to our rc script running, it was mounting it as RW, despite the fact that we are launching QEMU with the location as RO.