### PR TITLE
Fix Packer build example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 secrets.auto.pkrvars.hcl
-meta-data
-user-data
 cidata.*
 
 config/local.json

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ az sig image-definition create --resource-group <your RG name> --gallery-name <y
 
 Run packer build
 ```
-packer build -only=azure-arm.ubuntu --var aws_access_key=blah --var aws_secret_key=blah .
+packer build -only=azure-arm.ubuntu -var aws_access_key='' -var aws_secret_key='' -var-file=secrets.auto.pkrvars.hcl .
 ```
 ### AWS
 

--- a/main.pkr.hcl
+++ b/main.pkr.hcl
@@ -11,26 +11,6 @@ packer {
   }
 }
 
-# Cloud-init configuration files
-source "file" "user_data" {
-  content = <<-EOF
-    #cloud-config
-    user: ${var.ssh_username}
-    password: ${var.ssh_password}
-    chpasswd: { expire: False }
-    ssh_pwauth: True
-  EOF
-  target  = "user-data"
-}
-
-source "file" "meta_data" {
-  content = <<-EOF
-    instance-id: ubuntu-cloud
-    local-hostname: ubuntu-cloud
-  EOF
-  target  = "meta-data"
-}
-
 # Azure ARM Builder configuration
 source "azure-arm" "ubuntu" {
   use_azure_cli_auth = true

--- a/meta-data
+++ b/meta-data
@@ -1,0 +1,2 @@
+instance-id: ubuntu-cloud
+local-hostname: ubuntu-cloud

--- a/user-data
+++ b/user-data
@@ -1,0 +1,5 @@
+#cloud-config
+user: ${var.ssh_username}
+password: ${var.ssh_password}
+chpasswd: { expire: False }
+ssh_pwauth: True


### PR DESCRIPTION
This PR fixes the example Packer build from the README, adding in the reference to secret variables, correcting the number of hyphens, and moving the cloud-init definitions so that they're available at runtime.